### PR TITLE
Hotfix: probably deadlock introduced by dashmap.

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -318,15 +318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
-name = "ahash"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3e0bf23f51883cce372d5d5892211236856e4bb37fb942e1eb135ee0f146e3"
-dependencies = [
- "const-random",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,26 +570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-random"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"
-dependencies = [
- "const-random-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
-dependencies = [
- "getrandom",
- "proc-macro-hack",
-]
-
-[[package]]
 name = "copyless"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,13 +653,11 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "3.11.4"
+version = "4.0.0-rc5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfcd41ae02d60edded204341d2798ba519c336c51a37330aa4b98a1128def32"
+checksum = "372baa4d04520c054a54583609a80a271dd68162b0f24247e327d60f6aeab172"
 dependencies = [
- "ahash",
- "cfg-if",
- "num_cpus",
+ "once_cell",
 ]
 
 [[package]]
@@ -2148,6 +2117,7 @@ dependencies = [
  "async-trait",
  "awc",
  "base58",
+ "chrono",
  "config",
  "dashmap",
  "diesel",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,7 +16,10 @@ appinsights = { git = "https://github.com/zhzy0077/appinsights-rs", rev = "8d5b2
 async-trait = "0.1"
 awc = "1.0"
 base58 = "0.1"
+chrono = "0.4"
 config = "0.10"
+# Use preview version that is lock-free.
+dashmap = "4.0.0-rc5"
 diesel = { version = "1.4", features = ["postgres", "r2d2"] }
 diesel_migrations = "1.4"
 dotenv = "0.15"
@@ -31,4 +34,3 @@ serde_json = "1.0"
 simplelog = "0.8"
 url = "1.7"
 uuid = { version = "0.8", features = ["v4", "serde"] }
-dashmap = "3.11"

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -29,14 +29,9 @@ pub struct GitHubConfig {
 pub struct LogConfig {
     #[serde(default)]
     pub instrumentation_key: String,
-    pub logger: Logger,
+    #[serde(default)]
+    pub log_dir: String,
     pub level: Level,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub enum Logger {
-    ApplicationInsight,
-    TermLogger,
 }
 
 impl PipeHubConfig {


### PR DESCRIPTION
We notice that after deploying package w/ this commit https://github.com/zhzy0077/pipehub/commit/cf995fdf82cf9c02b75e72806b73e238b61ba98a. The server happens to be 100% CPU twice in 4 hrs. After validating the changes introduced by that commit. It's probably caused by the deadlock of dashmap. 

Upgrade the version of dashmap to a higher version which is lock-free as a work around.